### PR TITLE
Add InfoNCE contrastive loss for Moto-GPT pretraining

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,7 @@ cd ${PROJECT_ROOT}/scripts/
 nohup bash pretrain_moto_gpt_on_calvin.sh > pretrain_moto_gpt_on_calvin.log 2>&1 &
 tail -f pretrain_moto_gpt_on_calvin.log
 ```
-
-
+- The trainer now jitters brightness and contrast of the first frame and applies a symmetric InfoNCE loss between latent motion predictions from the original and augmented inputs.
 
 #### Pre-training on Open X-Embodiment datasets
 - Modify the `video_dir` and `lmdb_dir` fields in [moto_gpt/configs/data/rtx.yaml](moto_gpt/configs/data/rtx.yaml)


### PR DESCRIPTION
## Summary
- augment pretraining with color-jittered previous frames
- introduce a projection MLP and InfoNCE loss between predicted latent motions
- track contrastive loss during training
- document the new contrastive loss in README

## Testing
- `python -m py_compile moto_gpt/src/trainers/moto_gpt_trainer.py`
- `find moto_gpt common latent_motion_tokenizer -name '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_685bd82a5e88832caed3921c0cde2651